### PR TITLE
Fix variables in @media and improve width calculation

### DIFF
--- a/src/_base/functions.styl
+++ b/src/_base/functions.styl
@@ -1,5 +1,5 @@
 grid-column-width($n)
-  $column-width * $n - ($column-margin*($total-columns - $n)/$total-columns)
+  unit($column-width * $n - ($column-margin * ($total-columns - $n) / $total-columns), '%')
 
 grid-offset-length($n)
-  grid-column-width($n) + $column-margin
+  unit(grid-column-width($n) + $column-margin, '%')

--- a/src/_base/typography.styl
+++ b/src/_base/typography.styl
@@ -15,7 +15,7 @@ h5 { font-size: 1.8rem; line-height: 1.5;  letter-spacing: -.05rem; }
 h6 { font-size: 1.5rem; line-height: 1.6;  letter-spacing: 0;       }
 
 // Larger than phablet
-@media ($bp-larger-than-phablet) {
+@media ({$bp-larger-than-phablet}) {
   h1 { font-size: 5.0rem; }
   h2 { font-size: 4.2rem; }
   h3 { font-size: 3.6rem; }

--- a/src/_base/variables.styl
+++ b/src/_base/variables.styl
@@ -9,24 +9,24 @@ $bp-larger-than-desktop   := "min-width: 1000px"
 $bp-larger-than-desktophd := "min-width: 1200px"
 
 // Colors
-$light-grey:= #e1e1e1
-$dark-grey:= #333
-$primary-color:= #33c3f0
-$secondary-color:= lighten($dark-grey, 13.5%)
-$border-color:= #bbb
-$link-color:= #1eaedb
-$font-color:= #222
+$light-grey      := #e1e1e1
+$dark-grey       := #333
+$primary-color   := #33c3f0
+$secondary-color := lighten($dark-grey, 13.5%)
+$border-color    := #bbb
+$link-color      := #1eaedb
+$font-color      := #222
 
 // Typography
-$font-family:= "Raleway", "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif
+$font-family := "Raleway", "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif
 
-//Grid Variables
-$container-width:= 960px
-$container-width-larger-than-mobile:= 85%
-$container-width-larger-than-phablet:= 80%
-$total-columns:= 12
-$column-width:= 100 / $total-columns // calculates individual column width based off of # of columns
-$column-margin:= 4% // space between columns
+// Grid Variables
+$container-width := 960px
+$container-width-larger-than-mobile  := 85%
+$container-width-larger-than-phablet := 80%
+$total-columns := 12
+$column-width  := 100 / $total-columns // calculates individual column width based off of # of columns
+$column-margin := 4% // space between columns
 
 // Misc
-$global-radius:= 4px
+$global-radius := 4px

--- a/src/_base/variables.styl
+++ b/src/_base/variables.styl
@@ -26,7 +26,7 @@ $container-width-larger-than-mobile  := 85%
 $container-width-larger-than-phablet := 80%
 $total-columns := 12
 $column-width  := 100 / $total-columns // calculates individual column width based off of # of columns
-$column-margin := 4% // space between columns
+$column-margin := 4 // space between columns
 
 // Misc
 $global-radius := 4px

--- a/src/_modules/grid.styl
+++ b/src/_modules/grid.styl
@@ -29,7 +29,7 @@
   }
   .column,
   .columns {
-    margin-left: $column-margin;
+    margin-left: unit($column-margin, '%');
   }
   .column:first-child,
   .columns:first-child {

--- a/src/_modules/grid.styl
+++ b/src/_modules/grid.styl
@@ -15,7 +15,7 @@
 }
 
 // For devices larger than 400px
-@media ($bp-larger-than-mobile) {
+@media ({$bp-larger-than-mobile}) {
   .container {
     width: $container-width-larger-than-mobile;
     padding: 0;
@@ -23,7 +23,7 @@
 }
 
 // For devices larger than 550px
-@media ($bp-larger-than-phablet) {
+@media ({$bp-larger-than-phablet}) {
   .container {
     width: $container-width-larger-than-phablet;
   }

--- a/src/_modules/media-queries.styl
+++ b/src/_modules/media-queries.styl
@@ -7,16 +7,16 @@
 // there.
 
 // Larger than mobile
-@media ($bp-larger-than-mobile) {}
+@media ({$bp-larger-than-mobile}) {}
 
 // Larger than phablet (also point when grid becomes active)
-@media ($bp-larger-than-phablet) {}
+@media ({$bp-larger-than-phablet}) {}
 
 // Larger than tablet
-@media ($bp-larger-than-tablet) {}
+@media ({$bp-larger-than-tablet}) {}
 
 // Larger than desktop
-@media ($bp-larger-than-desktop) {}
+@media ({$bp-larger-than-desktop}) {}
 
 // Larger than Desktop HD
-@media ($bp-larger-than-desktophd) {}
+@media ({$bp-larger-than-desktophd}) {}


### PR DESCRIPTION
In stylus, *unit* is relevant, before we used `$column-margin := 4%`, and this is disrupting the width calculations.

For example, `six.columns` was returning `49%`, when it should be `48%`.

Remove unit from calculation and passing in return solved it.
